### PR TITLE
Adding a set of example build rules for plz

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -19,3 +19,4 @@ pythonpackage = third_party.python.google.protobuf
 grpcpythonplugin = `which grpc_python_plugin`
 ; Use a downloaded dep, this is easier to manage than a global installation.
 protocgoplugin = //third_party/go:protoc-gen-go
+grpcjavaplugin = //third_party/java:protoc-gen-grpc-java

--- a/.plzconfig
+++ b/.plzconfig
@@ -6,6 +6,10 @@
 ; run `./pleasew update` to update again.
 ;
 
+[python]
+; Makes recursive imports of third-party packages happier about this location.
+moduledir = third_party.python
+
 [proto]
 ; Imports protobuf from a non-usual directory in generated code.
 pythonpackage = third_party.python.google.protobuf

--- a/.plzconfig
+++ b/.plzconfig
@@ -6,6 +6,9 @@
 ; run `./pleasew update` to update again.
 ;
 
+[java]
+defaulttestpackage = net.thoughtmachine
+
 [python]
 ; Makes recursive imports of third-party packages happier about this location.
 moduledir = third_party.python

--- a/.plzconfig
+++ b/.plzconfig
@@ -5,3 +5,10 @@
 ; script for the first time it will fetch the latest version. Users can
 ; run `./pleasew update` to update again.
 ;
+
+[proto]
+; Imports protobuf from a non-usual directory in generated code.
+pythonpackage = third_party.python.google.protobuf
+grpcpythonplugin = `which grpc_python_plugin`
+; Use a downloaded dep, this is easier to manage than a global installation.
+protocgoplugin = //third_party/go:protoc-gen-go

--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -1,0 +1,8 @@
+# A filegroup is a rule that simply collects files and makes them available
+# to other rules. You can't use files that are 'owned' by another BUILD file
+# without one.
+filegroup(
+    name = 'integration_test',
+    srcs = ['integration_test.build_defs'],
+    visibility = ['PUBLIC'],
+)

--- a/build_defs/integration_test.build_defs
+++ b/build_defs/integration_test.build_defs
@@ -3,6 +3,21 @@
 # it's nicer to put them into separate files for reuse.
 
 
+# Some implementation details of the rules below.
+_KNOWN_LANGUAGES = {'cc', 'java', 'python', 'go'}
+
+_COMMAND_TEMPLATE = """
+%(server)s --port %(port)d &
+PID=$!
+# Wait a bit to give the server a chance to start.
+sleep 2s
+%(client)s --port %(port)d --breed %(breed)s
+RET=$?
+kill $PID
+exit $RET
+"""
+
+
 def integration_test(client, server, port, breed):
     """Defines a test that brings up a client and a server and has them communicate.
 
@@ -24,14 +39,14 @@ def integration_test(client, server, port, breed):
     test_cmd = _COMMAND_TEMPLATE % {
         'port': port,
         'breed': breed,
-        # $(location ) is obviously not a normal Bash pattern, it is something that
+        # $(location ) is not a normal Bash pattern, it is something that
         # Please replaces for you in commands. It's useful for finding the location
         # of an input file or rule.
         'client': '$(location %s)' % client_target,
         'server': '$(location %s)' % server_target,
     }
 
-    # gentest is an 'advanced' build rule which allows you to define an arbitrary
+    # gentest is an advanced build rule which allows you to define an arbitrary
     # test. It's relatively low-level compared to python_test or java_test etc,
     # but sometimes it's what you need.
     gentest(
@@ -49,21 +64,6 @@ def integration_test(client, server, port, breed):
         # Tests can be marked as flaky, in which case Please automatically retries
         # them up to three times. They pass as soon as any one passes.
         # In this case our tests can be a bit flaky because when they're all run
-        # at once sometimes things mysteriously time out.
+        # at once sometimes things time out.
         flaky = True,
     )
-
-
-# Some implementation details of the rule.
-_KNOWN_LANGUAGES = {'cc', 'java', 'python', 'go'}
-
-_COMMAND_TEMPLATE = """
-%(server)s --port %(port)d &
-PID=$!
-# Wait a bit to give the server a chance to start.
-sleep 2s
-%(client)s --port %(port)d --breed %(breed)s
-RET=$?
-kill $PID
-exit $RET
-"""

--- a/build_defs/integration_test.build_defs
+++ b/build_defs/integration_test.build_defs
@@ -1,0 +1,69 @@
+# build_defs files are files that define new build rules for Please.
+# It's actually possible to write these inline in BUILD files, but generally
+# it's nicer to put them into separate files for reuse.
+
+
+def integration_test(client, server, port, breed):
+    """Defines a test that brings up a client and a server and has them communicate.
+
+    The two aren't necessarily the same language, but they should all be able to
+    communicate with one another.
+
+    Args:
+      client: The language of the client.
+      server: The language of the server.
+      port: Port to run on.
+      breed: Breed of kitten to request. Each server can only provide one...
+    """
+    if client not in _KNOWN_LANGUAGES:
+        raise ValueError('Unknown client language: %s' % client)
+    if server not in _KNOWN_LANGUAGES:
+        raise ValueError('Unknown server language: %s' % server)
+    client_target = '//%s:client' % client
+    server_target = '//%s:server' % server
+    test_cmd = _COMMAND_TEMPLATE % {
+        'port': port,
+        'breed': breed,
+        # $(location ) is obviously not a normal Bash pattern, it is something that
+        # Please replaces for you in commands. It's useful for finding the location
+        # of an input file or rule.
+        'client': '$(location %s)' % client_target,
+        'server': '$(location %s)' % server_target,
+    }
+
+    # gentest is an 'advanced' build rule which allows you to define an arbitrary
+    # test. It's relatively low-level compared to python_test or java_test etc,
+    # but sometimes it's what you need.
+    gentest(
+        name = '%s_client_vs_%s_server_test' % (client, server),
+        test_cmd = test_cmd,
+        # The 'data' attribute defines runtime data files that are made available
+        # to the test in its work directory. It's useful for tests that need
+        # additional files in a predictable place but don't want to package them
+        # themselves.
+        data = [client_target, server_target],
+        # Normally tests produce an xUnit-style XML file or Go-format test output
+        # as results which Please parses. We're not going to do that so we'll be
+        # judged just on whether our test returns successfully or not.
+        no_test_output = True,
+        # Tests can be marked as flaky, in which case Please automatically retries
+        # them up to three times. They pass as soon as any one passes.
+        # In this case our tests can be a bit flaky because when they're all run
+        # at once sometimes things mysteriously time out.
+        flaky = True,
+    )
+
+
+# Some implementation details of the rule.
+_KNOWN_LANGUAGES = {'cc', 'java', 'python', 'go'}
+
+_COMMAND_TEMPLATE = """
+%(server)s --port %(port)d &
+PID=$!
+# Wait a bit to give the server a chance to start.
+sleep 2s
+%(client)s --port %(port)d --breed %(breed)s
+RET=$?
+kill $PID
+exit $RET
+"""

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -1,0 +1,55 @@
+# A cc_library compiles a reusable piece of C++ code into an object file
+# (or files) and archives them.
+cc_library(
+    name = 'kitten_lib',
+    srcs = ['kitten.cc', 'flags.cc'],
+    hdrs = ['kitten.h', 'flags.h'],
+    deps = [
+        '//proto:kitten',
+    ],
+)
+
+# A cc_binary links dependent C++ libraries into a standalone binary.
+# The process of building C++ code is complex and there are a number of options
+# on these rules to support it; we won't go into detail here, but note that
+# we don't have to pass any linker flags like -lprotobuf or -lgrpc; those are set
+# inside //proto:kitten and inherited by this rule.
+cc_binary(
+    name = 'client',
+    srcs = ['client.cc'],
+    deps = [
+        ':kitten_lib',
+        '//proto:kitten',
+    ],
+    visibility = ['PUBLIC'],
+)
+
+cc_binary(
+    name = 'server',
+    srcs = ['server.cc'],
+    deps = [
+        ':kitten_lib',
+        '//proto:kitten',
+    ],
+    visibility = ['PUBLIC'],
+)
+
+# A cc_test defines a C++ test using unittest++ for the test cases.
+# If you'd prefer not to use unittest++ you can supply your own test_main
+# and link against whatever test library you'd like.
+cc_test(
+    name = 'kitten_test',
+    srcs = ['kitten_test.cc', 'flags_test.cc'],
+    deps = [
+        ':kitten_lib',
+        '//proto:kitten',
+    ],
+    # Build rules can have arbitrary labels applied to them.
+    # Most of them are up to the user to define, but 'manual' is special;
+    # it means the test is only run when explicitly requested.
+    # We do that here because the various packages of unittest++ are very
+    # inconsistent about their install locations, and we don't want this
+    # entire repo to have a dependency on it. If you've got it installed
+    # and want to try it out, just run `plz test //cc:kitten_test`
+    labels = ['manual'],
+)

--- a/cc/client.cc
+++ b/cc/client.cc
@@ -1,0 +1,19 @@
+#include "cc/flags.h"
+#include "cc/kitten.h"
+#include "proto/kitten.grpc.pb.h"
+
+using thought_machine::GetFlag;
+
+int main(int argc, const char** argv) {
+  const char* port = GetFlag(argv, argv + argc, "--port");
+  port = port ? port : "9232";
+  const char* breed_flag = GetFlag(argv, argv + argc, "--breed");
+  Breed breed = HALP;
+  if (breed_flag && !Breed_Parse(breed_flag, &breed)) {
+    fprintf(stderr, "Unknown breed: %s\n", breed_flag);
+    exit(-1);
+  }
+  Kitten kitten = thought_machine::GetKitten(port, breed);
+  printf("Received kitten:\n%s\n", kitten.DebugString().c_str());
+  return 0;
+}

--- a/cc/flags.cc
+++ b/cc/flags.cc
@@ -1,0 +1,14 @@
+#include <algorithm>
+#include <string>
+
+namespace thought_machine {
+
+const char* GetFlag(const char** begin, const char** end, const std::string& flag) {
+    const char** it = std::find(begin, end, flag);
+    if (it != end && ++it != end) {
+        return *it;
+    }
+    return NULL;
+}
+
+}  // namespace thought_machine

--- a/cc/flags.h
+++ b/cc/flags.h
@@ -1,0 +1,18 @@
+#ifndef _CC_FLAGS_H
+#define _CC_FLAGS_H
+
+#include <string>
+
+namespace thought_machine {
+
+// Poor man's flag parsing, so we don't have to rely on gflags or similar being present.
+// Obviously it would be nicer to use a real library, but we don't want to make that
+// a hard requirement to build this repo since there isn't a very convenient way of
+// fetching C++ libraries.
+// Returns NULL if the flag can't be found.
+// Only works with separated options, doesn't support --flag=value format.
+const char* GetFlag(const char** begin, const char** end, const std::string& flag);
+
+}  // namespace thought_machine
+
+#endif  // _CC_FLAGS_H

--- a/cc/flags_test.cc
+++ b/cc/flags_test.cc
@@ -1,0 +1,13 @@
+#include <unittest++/UnitTest++.h>
+#include "cc/flags.h"
+
+namespace thought_machine {
+
+TEST(flags) {
+  const char* flags[] = {"--port", "9232", "--breed", "siamese"};
+  CHECK_EQUAL("9232", GetFlag(flags, flags + 4, "--port"));
+  CHECK_EQUAL("siamese", GetFlag(flags, flags + 4, "--breed"));
+  CHECK_EQUAL((const char*)NULL, GetFlag(flags, flags + 4, "--wibble"));
+}
+
+}  // namespace thought_machine

--- a/cc/kitten.cc
+++ b/cc/kitten.cc
@@ -1,0 +1,43 @@
+#include "cc/kitten.h"
+
+#include <memory>
+#include <string>
+#include <grpc++/grpc++.h>
+#include "proto/kitten.grpc.pb.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+
+namespace thought_machine {
+
+Kitten ProvideKitten() {
+  Kitten kitten;
+  kitten.set_name("Fluffy");
+  kitten.set_breed(BENGAL);
+  kitten.set_weight(1.5);
+  kitten.set_age(2);
+  return kitten;
+}
+
+Kitten GetKitten(const std::string& port, Breed breed) {
+  GetKittenRequest request;
+  if (breed) {
+    request.set_breed(breed);
+  }
+
+  std::shared_ptr<Channel> channel = grpc::CreateChannel(
+      "localhost:" + port, grpc::InsecureChannelCredentials());
+  std::unique_ptr<PetShop::Stub> stub(PetShop::NewStub(channel));
+
+  GetKittenResponse response;
+  ClientContext context;
+  Status status = stub->GetKitten(&context, request, &response);
+  if (!status.ok()) {
+    fprintf(stderr, "Failed to get kitten :(\n");
+    exit(1);
+  }
+  return response.kitten();
+}
+
+}  // namespace thought_machine

--- a/cc/kitten.h
+++ b/cc/kitten.h
@@ -1,0 +1,17 @@
+#ifndef _CC_KITTEN_H
+#define _CC_KITTEN_H
+
+#include <string>
+#include "proto/kitten.pb.h"
+
+namespace thought_machine {
+
+// Provides the standard kitten that this server has.
+Kitten ProvideKitten();
+
+// Retrieves a kitten from the remote server.
+Kitten GetKitten(const std::string& port, Breed breed);
+
+}  // namespace thought_machine
+
+#endif  // _CC_KITTEN_H

--- a/cc/kitten_test.cc
+++ b/cc/kitten_test.cc
@@ -1,0 +1,12 @@
+#include <unittest++/UnitTest++.h>
+#include "cc/kitten.h"
+
+namespace thought_machine {
+
+TEST(provide_kitten) {
+  Kitten kitten = ProvideKitten();
+  CHECK_EQUAL("Fluffy", kitten.name());
+  CHECK_EQUAL(BENGAL, kitten.breed());
+}
+
+}  // namespace thought_machine

--- a/cc/server.cc
+++ b/cc/server.cc
@@ -1,0 +1,36 @@
+#include <memory>
+#include <string>
+#include <grpc++/grpc++.h>
+#include "cc/flags.h"
+#include "cc/kitten.h"
+#include "proto/kitten.grpc.pb.h"
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+using thought_machine::GetFlag;
+
+class PetShopService : public PetShop::Service {
+  Status GetKitten(ServerContext*,
+                   const GetKittenRequest*,
+                   GetKittenResponse* reply) {
+    reply->mutable_kitten()->CopyFrom(thought_machine::ProvideKitten());
+    return Status::OK;
+  }
+};
+
+int main(int argc, const char** argv) {
+  const char* port_flag = GetFlag(argv, argv + argc, "--port");
+  std::string server_address("localhost:");
+  server_address += port_flag ? port_flag : "9232";
+
+  PetShopService service;
+  ServerBuilder builder;
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  builder.RegisterService(&service);
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+  fprintf(stderr, "Serving on %s\n", server_address.c_str());
+  server->Wait();  // Probably won't ever return.
+  return 0;
+}

--- a/go/BUILD
+++ b/go/BUILD
@@ -1,0 +1,40 @@
+go_library(
+    name = 'kittenlib',
+    srcs = ['kitten.go'],
+    deps = [
+        '//proto:kitten',
+        '//third_party/go:grpc',
+    ],
+)
+
+go_test(
+    name = 'kitten_test',
+    srcs = ['kitten_test.go'],
+    deps = [
+        ':kittenlib',
+        '//third_party/go:testify',
+    ],
+)
+
+go_binary(
+    name = 'client',
+    main = 'client.go',
+    deps = [
+        ':kittenlib',
+        '//proto:kitten',
+        '//third_party/go:go-flags',
+    ],
+    visibility = ['PUBLIC'],
+)
+
+go_binary(
+    name = 'server',
+    main = 'server.go',
+    deps = [
+        ':kittenlib',
+        '//proto:kitten',
+        '//third_party/go:grpc',
+        '//third_party/go:go-flags',
+    ],
+    visibility = ['PUBLIC'],
+)

--- a/go/BUILD
+++ b/go/BUILD
@@ -1,3 +1,6 @@
+# A go_library is a collection of Go files compiled into one package.
+# Typically you'd have one of these per directory, corresponding to the
+# Go package structure.
 go_library(
     name = 'kittenlib',
     srcs = ['kitten.go'],
@@ -7,15 +10,9 @@ go_library(
     ],
 )
 
-go_test(
-    name = 'kitten_test',
-    srcs = ['kitten_test.go'],
-    deps = [
-        ':kittenlib',
-        '//third_party/go:testify',
-    ],
-)
-
+# A go_binary builds a self-contained Go executable.
+# Note that unlike normal 'go build', there is no requirement to
+# necessarily have these in their own packages.
 go_binary(
     name = 'client',
     main = 'client.go',
@@ -37,4 +34,16 @@ go_binary(
         '//third_party/go:go-flags',
     ],
     visibility = ['PUBLIC'],
+)
+
+# A go_test is similar to a go_binary in that it builds a self-contained
+# executable, but it's typically run through 'plz test' to run all its
+# tests and report their results.
+go_test(
+    name = 'kitten_test',
+    srcs = ['kitten_test.go'],
+    deps = [
+        ':kittenlib',
+        '//third_party/go:testify',
+    ],
 )

--- a/go/BUILD
+++ b/go/BUILD
@@ -1,6 +1,9 @@
 # A go_library is a collection of Go files compiled into one package.
 # Typically you'd have one of these per directory, corresponding to the
-# Go package structure.
+# Go package structure. Please doesn't fundamentally require that you obey
+# that structure but if you don't there's a reasonable chance of running
+# afoul of obtuse compiler errors.
+
 go_library(
     name = 'kittenlib',
     srcs = ['kitten.go'],

--- a/go/client.go
+++ b/go/client.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+
+	"go/kittenlib"
+	pb "proto/kitten"
+)
+
+var opts struct {
+	Port  int    `short:"p" long:"port" default:"9232" description:"Port to communicate with server on"`
+	Breed string `short:"b" long:"breed" default:"HALP" description:"Breed of kitten to request"`
+}
+
+func main() {
+	if _, err := flags.ParseArgs(&opts, os.Args); err != nil {
+		os.Exit(1)
+	}
+	breed, present := pb.Breed_value[opts.Breed]
+	if !present {
+		log.Fatalf("Unknown breed: %s", breed)
+	}
+	kitten := kittenlib.GetKitten(opts.Port, pb.Breed(breed))
+	fmt.Printf("Received a kitten:\n%s\n", kitten)
+}

--- a/go/kitten.go
+++ b/go/kitten.go
@@ -30,7 +30,10 @@ func FetchKitten(request *pb.GetKittenRequest, port int) *pb.GetKittenResponse {
 	client := pb.NewPetShopClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	response, err := client.GetKitten(ctx, request)
+	// Don't fail fast, it's awkward in the integration tests if servers aren't
+	// ready yet, especially since Go tends to be faster initialising than at
+	// least some of the others.
+	response, err := client.GetKitten(ctx, request, grpc.FailFast(false))
 	if err != nil {
 		log.Fatalf("Failed to fetch kitten: %s", err)
 	}

--- a/go/kitten.go
+++ b/go/kitten.go
@@ -1,0 +1,60 @@
+package kittenlib
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	pb "proto/kitten"
+)
+
+// PetShopServer is the server implementation.
+type PetShopServer struct{}
+
+// GetKitten implements the proto RPC call.
+func (s *PetShopServer) GetKitten(ctx context.Context, req *pb.GetKittenRequest) (*pb.GetKittenResponse, error) {
+	return &pb.GetKittenResponse{Kitten: ProvideKitten()}, nil
+}
+
+// FetchKitten contacts the remote server to retrieve a kitten.
+func FetchKitten(request *pb.GetKittenRequest, port int) *pb.GetKittenResponse {
+	address := fmt.Sprintf("localhost:%d", port)
+	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Failed to connect to %s: %s", address, err)
+	}
+	defer conn.Close()
+	client := pb.NewPetShopClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	response, err := client.GetKitten(ctx, request)
+	if err != nil {
+		log.Fatalf("Failed to fetch kitten: %s", err)
+	}
+	return response
+}
+
+// GetKitten returns a kitten, optionally of the given breed.
+func GetKitten(port int, breed pb.Breed) *pb.Kitten {
+	request := pb.GetKittenRequest{}
+	if breed != pb.Breed_HALP {
+		request.Breed = breed
+	}
+	response := FetchKitten(&request, port)
+	if breed != pb.Breed_HALP && response.Kitten.Breed != breed {
+		log.Fatalf("Unexpected breed returned: %s", response.Kitten.Breed)
+	}
+	return response.Kitten
+}
+
+func ProvideKitten() *pb.Kitten {
+	return &pb.Kitten{
+		Name:   "Mighty Paws",
+		Breed:  pb.Breed_RUSSIAN_BLUE,
+		Age:    5,
+		Weight: 2.4,
+	}
+}

--- a/go/kitten_test.go
+++ b/go/kitten_test.go
@@ -1,0 +1,15 @@
+package kittenlib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pb "proto/kitten"
+)
+
+func TestProvideKitten(t *testing.T) {
+	kitten := ProvideKitten()
+	assert.Equal(t, pb.Breed_RUSSIAN_BLUE, kitten.Breed)
+	assert.Equal(t, "Mighty Paws", kitten.Name)
+}

--- a/go/server.go
+++ b/go/server.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+	"google.golang.org/grpc"
+
+	"go/kittenlib"
+	pb "proto/kitten"
+)
+
+var opts struct {
+	Port int `short:"p" long:"port" default:"9232" description:"Port to serve on"`
+}
+
+func main() {
+	if _, err := flags.ParseArgs(&opts, os.Args); err != nil {
+		os.Exit(1)
+	}
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", opts.Port))
+	if err != nil {
+		log.Fatalf("Failed to bind to port %d: %s", opts.Port, err)
+	}
+	s := grpc.NewServer()
+	pb.RegisterPetShopServer(s, &kittenlib.PetShopServer{})
+	fmt.Printf("Serving on port %d\n", opts.Port)
+	s.Serve(lis)
+}

--- a/java/BUILD
+++ b/java/BUILD
@@ -22,6 +22,11 @@ java_binary(
     deps = [
         ':lib',
     ],
+    # Setting this marks the .jar as executable and puts a shebang on the beginning
+    # so you can run it directly in a shell. It's not the default for historical
+    # reasons which really aren't very interesting.
+    self_executable = True,
+    visibility = ['PUBLIC'],
 )
 
 java_binary(
@@ -30,6 +35,8 @@ java_binary(
     deps = [
         ':lib',
     ],
+    self_executable = True,
+    visibility = ['PUBLIC'],
 )
 
 # A java_test is similar to a java_binary but is run through 'plz test'

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,0 +1,46 @@
+# A java_library compiles a number of Java files into .class
+# files and binds them up in a small .jar.
+java_library(
+    name = 'lib',
+    # glob() is useful for cases like this where we want to collect
+    # multiple source files of a type, often in a directory, and we
+    # don't want to have to list them all explicitly.
+    srcs = glob(['src/main/java/**/*.java']),
+    deps = [
+        '//proto:kitten',
+        '//third_party/java:args4j',
+        '//third_party/java:grpc-all',
+    ],
+)
+
+# A java_binary concatenates together all the libraries it depends on
+# into one uber-jar that can be deployed & run easily.
+java_binary(
+    name = 'client',
+    # This tells it what it should use for the Main-Class attribute in the manifest.
+    main_class = 'net.thoughtmachine.please.examples.KittenClient',
+    deps = [
+        ':lib',
+    ],
+)
+
+java_binary(
+    name = 'server',
+    main_class = 'net.thoughtmachine.please.examples.KittenServer',
+    deps = [
+        ':lib',
+    ],
+)
+
+# A java_test is similar to a java_binary but is run through 'plz test'
+# which runs all its tests and collects the results.
+java_test(
+    name = 'kitten_test',
+    srcs = glob(['src/test/java/**/*.java']),
+    deps = [
+        ':lib',
+        '//proto:kitten',
+        '//third_party/java:junit',
+        '//third_party/java:mockito',
+    ],
+)

--- a/java/src/main/java/net/thoughtmachine/please/examples/KittenClient.java
+++ b/java/src/main/java/net/thoughtmachine/please/examples/KittenClient.java
@@ -1,0 +1,25 @@
+package net.thoughtmachine.please.examples;
+
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+class KittenClient {
+
+  @Option(name = "--port", usage = "Port to connect to")
+  private int port = 9232;
+
+  @Option(name = "--breed", usage = "Breed of kitten to request")
+  private KittenProto.Breed breed;
+
+  void run(String[] args) throws Exception {
+    CmdLineParser parser = new CmdLineParser(this);
+    parser.parseArgument(args);
+    KittenProto.Kitten kitten = new Kittens().getKitten(port, breed);
+    System.out.printf("Received a kitten:\n%s\n", kitten.toString());
+  }
+
+  public static void main(String[] args) throws Exception {
+    new KittenClient().run(args);
+  }
+}

--- a/java/src/main/java/net/thoughtmachine/please/examples/KittenServer.java
+++ b/java/src/main/java/net/thoughtmachine/please/examples/KittenServer.java
@@ -1,0 +1,60 @@
+package net.thoughtmachine.please.examples;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+class KittenServer {
+
+  @Option(name = "--port", usage = "Port to serve on")
+  private int port = 9232;
+
+  Server server;
+
+  private void serve() throws Exception {
+    server = ServerBuilder.forPort(port)
+        .addService(PetShopGrpc.bindService(new PetShopService()))
+        .build()
+        .start();
+    System.out.printf("Server started, listening on %d\n", port);
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        System.err.println("*** shutting down gRPC server since JVM is shutting down");
+        KittenServer.this.stop();
+        System.err.println("*** server shut down");
+      }
+    });
+    server.awaitTermination();
+  }
+
+  private void stop() {
+    if (server != null) {
+      server.shutdown();
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    KittenServer server = new KittenServer();
+    CmdLineParser parser = new CmdLineParser(server);
+    parser.parseArgument(args);
+    server.serve();
+  }
+
+  private class PetShopService implements PetShopGrpc.PetShop {
+    @Override
+    public void getKitten(KittenProto.GetKittenRequest req,
+        StreamObserver<KittenProto.GetKittenResponse> responseObserver) {
+      KittenProto.GetKittenResponse response = KittenProto.GetKittenResponse.newBuilder()
+          .setKitten(Kittens.provideKitten())
+          .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+}

--- a/java/src/main/java/net/thoughtmachine/please/examples/Kittens.java
+++ b/java/src/main/java/net/thoughtmachine/please/examples/Kittens.java
@@ -1,0 +1,53 @@
+package net.thoughtmachine.please.examples;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+
+import java.util.concurrent.TimeUnit;
+
+class Kittens {
+
+  public static KittenProto.Kitten provideKitten() {
+    return KittenProto.Kitten.newBuilder()
+        .setName("Speedy Hunter")
+        .setBreed(KittenProto.Breed.PERSIAN)
+        .setWeight(3.0f)
+        .setAge(7)
+        .build();
+  }
+
+  KittenProto.GetKittenResponse fetchKitten(KittenProto.GetKittenRequest request, int port) {
+    ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", port)
+        .usePlaintext(true)
+        .build();
+    PetShopGrpc.PetShopBlockingStub stub = PetShopGrpc.newBlockingStub(channel);
+    try {
+      return stub.getKitten(request);
+    } catch (StatusRuntimeException ex) {
+      throw new RuntimeException(ex);
+    } finally {
+      try {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+      } catch (InterruptedException ex) {
+      }
+    }
+  }
+
+  public KittenProto.Kitten getKitten(int port, KittenProto.Breed breed) {
+    KittenProto.GetKittenRequest.Builder builder = KittenProto.GetKittenRequest.newBuilder();
+    if (breed != null) {
+      builder.setBreed(breed);
+    }
+    KittenProto.GetKittenResponse response = fetchKitten(builder.build(), port);
+    if (breed != null && breed != response.getKitten().getBreed()) {
+      throw new RuntimeException("Unexpected kitten breed: " + response.getKitten().getBreed().toString());
+    }
+    return response.getKitten();
+  }
+
+  public KittenProto.Kitten getKitten(int port) {
+    return getKitten(port, null);
+  }
+
+}

--- a/java/src/test/java/net/thoughtmachine/please/examples/KittensTest.java
+++ b/java/src/test/java/net/thoughtmachine/please/examples/KittensTest.java
@@ -1,0 +1,43 @@
+package net.thoughtmachine.please.examples;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KittensTest {
+
+  private static final int PORT = 80;  // doesn't matter.
+
+  private Kittens kittens;
+
+  @Before
+  public void setUp() {
+    // Mock this so we don't connect to a server.
+    kittens = mock(Kittens.class);
+    when(kittens.fetchKitten(any(KittenProto.GetKittenRequest.class), anyInt()))
+        .thenReturn(KittenProto.GetKittenResponse.newBuilder()
+            .setKitten(Kittens.provideKitten())
+            .build());
+    when(kittens.getKitten(anyInt(), any(KittenProto.Breed.class)))
+        .thenCallRealMethod();
+    when(kittens.getKitten(anyInt()))
+        .thenCallRealMethod();
+  }
+
+  @Test
+  public void testGetKitten() {
+    KittenProto.Kitten kitten = kittens.getKitten(PORT);
+    assertEquals("Speedy Hunter", kitten.getName());
+    assertEquals(KittenProto.Breed.PERSIAN, kitten.getBreed());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testGetKittenOfWrongBreed() {
+    kittens.getKitten(PORT, KittenProto.Breed.CORNISH_REX);
+  }
+}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,4 +1,5 @@
 grpc_library(
     name = 'kitten',
     srcs = ['kitten.proto'],
+    visibility = ['PUBLIC'],
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,0 +1,4 @@
+grpc_library(
+    name = 'kitten',
+    srcs = ['kitten.proto'],
+)

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,3 +1,11 @@
+# grpc_library compiles a .proto file with rpc endpoints into
+# language-specific implementations. It creates a series of internal rules
+# for each language so you don't need to add another go_library etc to make
+# use of the output, and each language will automatically depend on the
+# appropriate implementation.
+#
+# See https://developers.google.com/protocol-buffers and http://grpc.io for
+# general information about gRPC and protobufs.
 grpc_library(
     name = 'kitten',
     srcs = ['kitten.proto'],

--- a/proto/kitten.proto
+++ b/proto/kitten.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 
+option java_package = "net.thoughtmachine.please.examples";
+option java_outer_classname = "KittenProto";
+
 service PetShop {
     // Supplies one kitten to the caller.
     rpc GetKitten(GetKittenRequest) returns (GetKittenResponse);

--- a/proto/kitten.proto
+++ b/proto/kitten.proto
@@ -16,10 +16,8 @@ enum Breed {
 message Kitten {
     string name = 1;
     Breed breed = 2;
-    float weight = 3;
-    int32 age = 4;
-    int64 dob = 5;
-    bool neutered = 6;
+    float weight = 3;  // in kg
+    int32 age = 4;  // in cat years
 }
 
 message GetKittenRequest {

--- a/proto/kitten.proto
+++ b/proto/kitten.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+service PetShop {
+    // Supplies one kitten to the caller.
+    rpc GetKitten(GetKittenRequest) returns (GetKittenResponse);
+}
+
+enum Breed {
+    HALP = 0;
+    PERSIAN = 1;
+    BENGAL = 2;
+    RUSSIAN_BLUE = 3;
+    CORNISH_REX = 4;
+}
+
+message Kitten {
+    string name = 1;
+    Breed breed = 2;
+    float weight = 3;
+    int32 age = 4;
+    int64 dob = 5;
+    bool neutered = 6;
+}
+
+message GetKittenRequest {
+    // Breed of kitten requested. If not given then the server
+    // may provide a kitten of any breed.
+    Breed breed = 1;
+}
+
+message GetKittenResponse {
+    Kitten kitten = 1;
+}

--- a/python/BUILD
+++ b/python/BUILD
@@ -1,0 +1,38 @@
+python_library(
+    name = 'kitten_lib',
+    srcs = ['kitten_lib.py'],
+    deps = [
+        '//proto:kitten',
+        '//third_party/python:grpc',
+    ],
+)
+
+python_binary(
+    name = 'client',
+    main = 'client.py',
+    deps = [
+        ':kitten_lib',
+        '//proto:kitten',
+        '//third_party/python:gflags',
+    ],
+    zip_safe = False,  # Should not be needed after #119 is fixed
+)
+
+python_binary(
+    name = 'server',
+    main = 'server.py',
+    deps = [
+        ':kitten_lib',
+        '//proto:kitten',
+        '//third_party/python:gflags',
+    ],
+    zip_safe = False,
+)
+
+python_test(
+    name = 'kitten_test',
+    srcs = ['kitten_test.py'],
+    deps = [
+        ':kitten_lib',
+    ],
+)

--- a/python/BUILD
+++ b/python/BUILD
@@ -1,3 +1,5 @@
+# A python_library defines a reusable piece of Python code; this one we
+# will share between the client and server, and test it below.
 python_library(
     name = 'kitten_lib',
     srcs = ['kitten_lib.py'],
@@ -7,6 +9,8 @@ python_library(
     ],
 )
 
+# A python_binary builds a pex, a self-contained Python archive with
+# third-party dependencies included. These can be deployed and run easily.
 python_binary(
     name = 'client',
     main = 'client.py',
@@ -16,6 +20,7 @@ python_binary(
         '//third_party/python:gflags',
     ],
     zip_safe = False,  # Should not be needed after #119 is fixed
+    visibility = ['PUBLIC'],
 )
 
 python_binary(
@@ -27,8 +32,11 @@ python_binary(
         '//third_party/python:gflags',
     ],
     zip_safe = False,
+    visibility = ['PUBLIC'],
 )
 
+# A python_test also builds a pex, but is typically executed through
+# plz test which runs all the tests in it and produces the results.
 python_test(
     name = 'kitten_test',
     srcs = ['kitten_test.py'],

--- a/python/BUILD
+++ b/python/BUILD
@@ -11,6 +11,8 @@ python_library(
 
 # A python_binary builds a pex, a self-contained Python archive with
 # third-party dependencies included. These can be deployed and run easily.
+# See https://github.com/pantsbuild/pex for more general information about
+# pexes and how they work and what they're useful for.
 python_binary(
     name = 'client',
     main = 'client.py',
@@ -19,7 +21,6 @@ python_binary(
         '//proto:kitten',
         '//third_party/python:gflags',
     ],
-    zip_safe = False,  # Should not be needed after #119 is fixed
     visibility = ['PUBLIC'],
 )
 
@@ -31,7 +32,6 @@ python_binary(
         '//proto:kitten',
         '//third_party/python:gflags',
     ],
-    zip_safe = False,
     visibility = ['PUBLIC'],
 )
 

--- a/python/client.py
+++ b/python/client.py
@@ -1,0 +1,20 @@
+import sys
+from third_party.python import gflags as flags
+from proto import kitten_pb2
+from python.kitten_lib import get_kitten
+
+
+flags.DEFINE_integer('port', 9232, 'The port to connect to')
+flags.DEFINE_enum('breed', None, kitten_pb2.Breed.keys(),
+                  'Breed of kitten to request')
+FLAGS = flags.FLAGS
+
+
+def main():
+    kitten = get_kitten(FLAGS.port, breed=FLAGS.breed)
+    print('Received a kitten:\n%s' % kitten)
+
+
+if __name__ == '__main__':
+    FLAGS(sys.argv)
+    main()

--- a/python/kitten_lib.py
+++ b/python/kitten_lib.py
@@ -25,9 +25,9 @@ def get_kitten(port, breed=None):
     """
     request = kitten_pb2.GetKittenRequest()
     if breed:
-        request.breed = Breed
+        request.breed = kitten_pb2.Breed.Value(breed)
     response = fetch_kitten(request, port)
-    if breed and response.kitten.breed != breed:
+    if breed and response.kitten.breed != request.breed:
         raise Exception('Unacceptable kitten breed: %s' % response.kitten.breed)
     return response.kitten
 

--- a/python/kitten_lib.py
+++ b/python/kitten_lib.py
@@ -1,0 +1,42 @@
+from third_party.python.grpc.beta.implementations import insecure_channel
+from proto import kitten_pb2
+
+
+def fetch_kitten(request, port):
+    """Fetches a kitten from the server.
+
+    :param kitten_pb2.GetKittenRequest request: Request proto for the kitten.
+    :param int port: Port to communicate with the server on.
+    :return: The response proto describing the kitten.
+    :rtype: kitten_pb2.GetKittenResponse
+    """
+    channel = insecure_channel('localhost', port)
+    with kitten_pb2.beta_create_PetShop_stub(channel) as stub:
+        return stub.GetKitten(request, 3)
+
+
+def get_kitten(port, breed=None):
+    """Returns a kitten, optionally specifying a required breed.
+
+    :param int port: Port to communicate with the server on.
+    :param kitten_pb2.Breed breed: Required breed of the kitten.
+    :return: The kitten retrieved.
+    :rtype: kitten_pb2.Kitten
+    """
+    request = kitten_pb2.GetKittenRequest()
+    if breed:
+        request.breed = Breed
+    response = fetch_kitten(request, port)
+    if breed and response.kitten.breed != breed:
+        raise Exception('Unacceptable kitten breed: %s' % response.kitten.breed)
+    return response.kitten
+
+
+def provide_kitten():
+    """Returns a kitten of the breed we have available."""
+    return kitten_pb2.Kitten(
+        name='Mr Tibbles',
+        breed=kitten_pb2.CORNISH_REX,
+        weight=2.0,
+        age=3,
+    )

--- a/python/kitten_test.py
+++ b/python/kitten_test.py
@@ -1,0 +1,28 @@
+import unittest
+
+from proto import kitten_pb2
+from python import kitten_lib
+
+
+class KittenTest(unittest.TestCase):
+
+    def setUp(self):
+        # Mock out stub call for testing.
+        kitten_lib.fetch_kitten = lambda *args, **kwargs: kitten_pb2.GetKittenResponse(
+            kitten=kitten_lib.provide_kitten())
+        self.port = 80  # Doesn't matter.
+
+    def test_any_breed(self):
+        """Test us requesting a kitten of any breed."""
+        kitten = kitten_lib.get_kitten(self.port)
+        self.assertEqual('Mr Tibbles', kitten.name)
+        self.assertEqual(kitten_pb2.CORNISH_REX, kitten.breed)
+
+    def test_breed_request(self):
+        """Test that an exception is thrown when we request a kitten of another breed."""
+        with self.assertRaises(Exception):
+            kitten_lib.get_kitten(self.port, breed=kitten_pb2.PERSIAN)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/server.py
+++ b/python/server.py
@@ -1,0 +1,33 @@
+import sys
+import time
+from third_party.python import gflags as flags
+from proto import kitten_pb2
+from python.kitten_lib import provide_kitten
+
+
+flags.DEFINE_integer('port', 9232, 'The port to serve on')
+FLAGS = flags.FLAGS
+
+
+class PetShop(kitten_pb2.BetaPetShopServicer):
+
+    def GetKitten(self, request, context):
+        return kitten_pb2.GetKittenResponse(kitten=provide_kitten())
+
+
+
+def main():
+    server = kitten_pb2.beta_create_PetShop_server(PetShop())
+    server.add_insecure_port("localhost:%s" % FLAGS.port)
+    server.start()
+    print('Serving on port %d' % FLAGS.port)
+    try:
+        while True:
+            time.sleep(100000)
+    except KeyboardInterrupt:
+        server.stop(0)
+
+
+if __name__ == '__main__':
+    FLAGS(sys.argv)
+    main()

--- a/python/server.py
+++ b/python/server.py
@@ -15,7 +15,6 @@ class PetShop(kitten_pb2.BetaPetShopServicer):
         return kitten_pb2.GetKittenResponse(kitten=provide_kitten())
 
 
-
 def main():
     server = kitten_pb2.beta_create_PetShop_server(PetShop())
     server.add_insecure_port("localhost:%s" % FLAGS.port)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,33 @@
+# subinclude loads build rules from another file (specifically, from the
+# output of another build rule). The rules appear directly in
+# the current global namespace, so it's a bit more akin to a C include
+# than a Python import.
+subinclude('//build_defs:integration_test')
+
+# This file demonstrates how to do some slightly more powerful things
+# with Please; here we generate a set of integration tests between
+# all the client-server pairs.
+
+# Each server will only supply one kitten, so we match up breeds here.
+BREEDS = {
+    'python': 'CORNISH_REX',
+    'java': 'PERSIAN',
+    'cc': 'BENGAL',
+    'go': 'RUSSIAN_BLUE',
+}
+
+# Better make sure they all choose a different port...
+port = 9000
+
+for server, breed in BREEDS.items():
+    for client in BREEDS:
+        # This is a new build rule that was loaded in the subinclude() call earlier.
+        # See build_defs/integration_test.build_defs if you're curious about how
+        # it's defined.
+        integration_test(
+            client = client,
+            server = server,
+            port = port,
+            breed = breed,
+        )
+        port += 1

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,10 +1,15 @@
+# This says that all targets in this package that don't specify otherwise
+# will be visible to the whole repo.
+# This is often useful for third-party packages like this where we expect
+# anyone to use them.
 package(default_visibility = ['PUBLIC'])
 
+# go_get invokes, not surprisingly, 'go get' to fetch a third-party package.
+# Note that we can specify Git revisions to pin them to a particular version.
 go_get(
     name = 'grpc',
     get = 'google.golang.org/grpc',
     revision = '461dac99975b211ed3eda7eb45b997d82da4345a',
-    install = ['google.golang.org/grpc/health'],
     deps = [
         ':protobuf',
     ],
@@ -14,6 +19,9 @@ go_get(
     name = 'protoc-gen-go',
     get = 'github.com/golang/protobuf/protoc-gen-go',
     revision = '3852dcfda249c2097355a6aabb199a28d97b30df',
+    # This produces an executable tool that we use elsewhere;
+    # marking this makes it easy to use in other rules or through
+    # plz run since it will only produce a single output.
     binary = True,
 )
 
@@ -27,6 +35,11 @@ go_get(
     name = 'testify',
     get = 'github.com/stretchr/testify',
     revision = 'f390dcf405f7b83c997eac1b06768bb9f44dec18',
+    # This means that this library will only be able to be used by tests
+    # (go_test rules and so forth). Obviously we'd be unlikely to use
+    # testify in production code, but it can be useful to enforce these
+    # things so nobody introduces such a dependency by accident.
+    test_only = True,
 )
 
 go_get(

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -22,3 +22,15 @@ go_get(
     get = 'github.com/golang/protobuf/proto',
     revision = '3852dcfda249c2097355a6aabb199a28d97b30df',
 )
+
+go_get(
+    name = 'testify',
+    get = 'github.com/stretchr/testify',
+    revision = 'f390dcf405f7b83c997eac1b06768bb9f44dec18',
+)
+
+go_get(
+    name = 'go-flags',
+    get = 'github.com/jessevdk/go-flags',
+    revision = '0a28dbe50f23d8fce6b016975b964cfe7b97a20a',
+)

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -4,7 +4,7 @@
 # anyone to use them.
 package(default_visibility = ['PUBLIC'])
 
-# go_get invokes, not surprisingly, 'go get' to fetch a third-party package.
+# go_get invokes, not unsurprisingly, 'go get' to fetch a third-party package.
 # Note that we can specify Git revisions to pin them to a particular version.
 go_get(
     name = 'grpc',
@@ -22,6 +22,9 @@ go_get(
     # This produces an executable tool that we use elsewhere;
     # marking this makes it easy to use in other rules or through
     # plz run since it will only produce a single output.
+    # Other rules would invoke it via a command like
+    # $(exe //third_party/go:protoc-gen-go) which Please will
+    # expand into the appropriate location.
     binary = True,
 )
 
@@ -36,8 +39,8 @@ go_get(
     get = 'github.com/stretchr/testify',
     revision = 'f390dcf405f7b83c997eac1b06768bb9f44dec18',
     # This means that this library will only be able to be used by tests
-    # (go_test rules and so forth). Obviously we'd be unlikely to use
-    # testify in production code, but it can be useful to enforce these
+    # (go_test rules and so forth). We'd be unlikely to use testify in
+    # production code, but it can be useful to enforce these
     # things so nobody introduces such a dependency by accident.
     test_only = True,
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ['PUBLIC'])
+
+go_get(
+    name = 'grpc',
+    get = 'google.golang.org/grpc',
+    revision = '461dac99975b211ed3eda7eb45b997d82da4345a',
+    install = ['google.golang.org/grpc/health'],
+    deps = [
+        ':protobuf',
+    ],
+)
+
+go_get(
+    name = 'protoc-gen-go',
+    get = 'github.com/golang/protobuf/protoc-gen-go',
+    revision = '3852dcfda249c2097355a6aabb199a28d97b30df',
+    binary = True,
+)
+
+go_get(
+    name = 'protobuf',
+    get = 'github.com/golang/protobuf/proto',
+    revision = '3852dcfda249c2097355a6aabb199a28d97b30df',
+)

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ['PUBLIC'])
+
+maven_jar(
+    name = 'protobuf',
+    id = 'com.google.protobuf:protobuf-java:3.0.0-beta-3',
+    hash = 'ed118aa0276005ca49b18a3a2b77eaacdec95680',  # Verify that we get what we're expecting.
+    sources = False,  # Not available
+)
+
+maven_jar(
+    name = 'protobuf-java-util',
+    id = 'com.google.protobuf:protobuf-java-util:3.0.0-beta-3',
+    hash = 'e7fb40f29053441632277d75952874b3e03bf68a',
+    deps = [
+        ':protobuf',
+    ],
+    sources = False,
+)
+
+maven_jars(
+    name = 'grpc-all',
+    id = 'io.grpc:grpc-all:0.15.0',
+    exclude = [
+        'protobuf-java',
+        'protobuf-java-util',
+    ],
+    deps = [
+        ':protobuf-java-util',
+    ],
+)

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -26,6 +26,13 @@ maven_jar(
     sources = False,
 )
 
+maven_jar(
+    name = 'protoc-gen-grpc-java',
+    id = 'io.grpc:protoc-gen-grpc-java:0.15.0',
+    hash = '72b7fdc7047cd628f5c6365f8f2f255b8a293cb6',
+    binary = True,
+)
+
 # maven_jars fetches a library and its transitive dependencies from Maven.
 # A little fiddling is needed here to handle dependencies that have no
 # sources available.
@@ -48,7 +55,7 @@ maven_jar(
     hash = 'sha1: a791201ac8a3d2a251045a52e264de01343ad2df',
     # This means that this library will only be able to be used by tests
     # (go_test rules and so forth). Obviously we'd be unlikely to use
-    # testify in production code, but it can be useful to enforce these
+    # junit in production code, but it can be useful to enforce these
     # things so nobody introduces such a dependency by accident.
     test_only = True,
 )

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -1,5 +1,11 @@
+# This says that all targets in this package that don't specify otherwise
+# will be visible to the whole repo.
+# This is often useful for third-party packages like this where we expect
+# anyone to use them.
 package(default_visibility = ['PUBLIC'])
 
+# maven_jar fetches a single .jar file from Maven.
+# Note that it doesn't fetch dependencies, we have to specify them explicitly.
 maven_jar(
     name = 'protobuf',
     id = 'com.google.protobuf:protobuf-java:3.0.0-beta-3',
@@ -17,6 +23,10 @@ maven_jar(
     sources = False,
 )
 
+# maven_jars fetches a library and its transitive dependencies from Maven.
+# A little fiddling is needed here to handle dependencies that have no
+# sources available.
+# TODO(pebers): Revisit this once issue #120 is resolved.
 maven_jars(
     name = 'grpc-all',
     id = 'io.grpc:grpc-all:0.15.0',

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -9,7 +9,10 @@ package(default_visibility = ['PUBLIC'])
 maven_jar(
     name = 'protobuf',
     id = 'com.google.protobuf:protobuf-java:3.0.0-beta-3',
-    hash = 'ed118aa0276005ca49b18a3a2b77eaacdec95680',  # Verify that we get what we're expecting.
+    # Please can hash-verify downloaded artifacts so you're sure you get
+    # what you're expecting. This is particularly useful when fetching things
+    # from external repositories.
+    hash = 'ed118aa0276005ca49b18a3a2b77eaacdec95680',
     sources = False,  # Not available
 )
 
@@ -37,4 +40,28 @@ maven_jars(
     deps = [
         ':protobuf-java-util',
     ],
+)
+
+maven_jar(
+    name = 'junit',
+    id = 'junit:junit:4.12',
+    hash = 'sha1: a791201ac8a3d2a251045a52e264de01343ad2df',
+    # This means that this library will only be able to be used by tests
+    # (go_test rules and so forth). Obviously we'd be unlikely to use
+    # testify in production code, but it can be useful to enforce these
+    # things so nobody introduces such a dependency by accident.
+    test_only = True,
+)
+
+maven_jar(
+    name = 'mockito',
+    id = 'org.mockito:mockito-all:1.10.19',
+    hash = 'e93ceaea4cf704350fbb2a450ddbb7b4e3e062e3',
+    test_only = True,
+)
+
+maven_jar(
+    name = 'args4j',
+    id = 'args4j:args4j:2.32',
+    hash = 'a08fb9a7217df438872f27936058f594eab29396',
 )

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -1,0 +1,35 @@
+package(default_visibility = ['PUBLIC'])
+
+pip_library(
+    name = 'protobuf',
+    outs = ['google'],
+    version = '3.0.0b3',
+    deps = [
+        ':six',
+    ],
+)
+
+pip_library(
+    name = 'grpc',
+    package_name = 'grpcio',
+    version = '0.15.0',
+    deps = [':enum', ':futures'],
+)
+
+pip_library(
+    name = 'six',
+    version = '1.10.0',
+    outs = ['six.py'],
+)
+
+pip_library(
+    name = 'enum',
+    version = '1.1.6',
+    package_name = 'enum34',
+)
+
+pip_library(
+    name = 'futures',
+    version = '3.0.5',
+    outs = ['concurrent']
+)

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -1,5 +1,11 @@
+# This says that all targets in this package that don't specify otherwise
+# will be visible to the whole repo.
+# This is often useful for third-party packages like this where we expect
+# anyone to use them.
 package(default_visibility = ['PUBLIC'])
 
+# pip_library invokes pip to install a third-party library for us.
+# Note that dependencies have to be specified explicitly.
 pip_library(
     name = 'protobuf',
     outs = ['google'],
@@ -20,6 +26,8 @@ pip_library(
 pip_library(
     name = 'six',
     version = '1.10.0',
+    # If the library doesn't output into a directory the same as the
+    # rule name, we have to tell Please what it's supposed to output here.
     outs = ['six.py'],
 )
 

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -14,6 +14,7 @@ pip_library(
     package_name = 'grpcio',
     version = '0.15.0',
     deps = [':enum', ':futures'],
+    zip_safe = False,  # cygrpc.so can't be imported from inside a .pex.
 )
 
 pip_library(
@@ -32,4 +33,10 @@ pip_library(
     name = 'futures',
     version = '3.0.5',
     outs = ['concurrent']
+)
+
+pip_library(
+    name = 'gflags',
+    version = '3.0.5',
+    package_name = 'python-gflags',
 )


### PR DESCRIPTION
As discussed on Friday, it's probably useful to have a sample repo illustrating how one would normally do things. The Please repo itself isn't ideal because there's quite a bit of contorting to bootstrap things.

Has a simple gRPC service with client/server implementations in four languages, and a set of integration tests between them which show off a slightly more complex way of generating build rules.
