### PR TITLE
to pep-8 for build and build_defs files

### DIFF
--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -2,7 +2,7 @@
 # to other rules. You can't use files that are 'owned' by another BUILD file
 # without one.
 filegroup(
-    name = 'integration_test',
-    srcs = ['integration_test.build_defs'],
-    visibility = ['PUBLIC'],
+    name='integration_test',
+    srcs=['integration_test.build_defs'],
+    visibility=['PUBLIC'],
 )

--- a/build_defs/integration_test.build_defs
+++ b/build_defs/integration_test.build_defs
@@ -50,25 +50,25 @@ def integration_test(client, server, port, breed):
     # test. It's relatively low-level compared to python_test or java_test etc,
     # but sometimes it's what you need.
     gentest(
-        name = '%s_client_vs_%s_server_test' % (client, server),
-        test_cmd = test_cmd,
+        name='%s_client_vs_%s_server_test' % (client, server),
+        test_cmd=test_cmd,
         # The 'data' attribute defines runtime data files that are made available
         # to the test in its work directory. It's useful for tests that need
         # additional files in a predictable place but don't want to package them
         # themselves.
-        data = [client_target, server_target],
+        data=[client_target, server_target],
         # Normally tests produce an xUnit-style XML file or Go-format test output
         # as results which Please parses. We're not going to do that so we'll be
         # judged just on whether our test returns successfully or not.
-        no_test_output = True,
+        no_test_output=True,
         # Tests can be marked as flaky, in which case Please automatically retries
         # them up to three times. They pass as soon as any one passes.
         # In this case our tests can be a bit flaky because when they're all run
         # at once sometimes things time out.
-        flaky = True,
+        flaky=True,
         # Labels are arbitrary string labels applied to tests, which lets them
         # be selected via the --include and --exclude command-line flags.
         # Here we tag the tests as integration tests (maybe a lightweight test
         # run might exclude those) and with the appropriate languages.
-        labels = [client, server, 'integration'],
+        labels=[client, server, 'integration'],
     )

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -1,16 +1,16 @@
 # A cc_library compiles a reusable piece of C++ code into an object file
 # (or files) and archives them.
 cc_library(
-    name = 'kitten_lib',
-    srcs = [
+    name='kitten_lib',
+    srcs=[
         'flags.cc',
         'kitten.cc',
     ],
-    hdrs = [
+    hdrs=[
         'flags.h',
         'kitten.h',
     ],
-    deps = [
+    deps=[
         '//proto:kitten',
     ],
 )
@@ -21,9 +21,9 @@ cc_library(
 # we don't have to pass any linker flags like -lprotobuf or -lgrpc; those are set
 # inside //proto:kitten and inherited by this rule.
 cc_binary(
-    name = 'client',
-    srcs = ['client.cc'],
-    deps = [
+    name='client',
+    srcs=['client.cc'],
+    deps=[
         ':kitten_lib',
         '//proto:kitten',
     ],
@@ -31,21 +31,21 @@ cc_binary(
 )
 
 cc_binary(
-    name = 'server',
-    srcs = ['server.cc'],
-    deps = [
+    name='server',
+    srcs=['server.cc'],
+    deps=[
         ':kitten_lib',
         '//proto:kitten',
     ],
-    visibility = ['PUBLIC'],
+    visibility=['PUBLIC'],
 )
 
 # A cc_test defines a C++ test using UnitTest++ for the test cases.
 # If you'd prefer not to use UnitTest++ you can supply your own test_main
 # and link against whatever test library you'd like.
 cc_test(
-    name = 'kitten_test',
-    srcs = [
+    name='kitten_test',
+    srcs=[
         'flags_test.cc',
         'kitten_test.cc',
     ],
@@ -56,8 +56,8 @@ cc_test(
     # inconsistent about their install locations, and we don't want this
     # entire repo to have a dependency on it. If you've got it installed
     # and want to try it out, just run `plz test //cc:kitten_test`
-    labels = ['manual'],
-    deps = [
+    labels=['manual'],
+    deps=[
         ':kitten_lib',
         '//proto:kitten',
     ],

--- a/go/client/BUILD
+++ b/go/client/BUILD
@@ -2,12 +2,12 @@
 # It is possible to put these in the same directory as the go_library rule,
 # but keeping them separate plays a little nicer with normal Go tools.
 go_binary(
-    name = 'client',
-    srcs = ['client.go'],
-    deps = [
+    name='client',
+    srcs=['client.go'],
+    deps=[
         '//go/lib',
         '//proto:kitten',
         '//third_party/go:go-flags',
     ],
-    visibility = ['PUBLIC'],
+    visibility=['PUBLIC'],
 )

--- a/go/lib/BUILD
+++ b/go/lib/BUILD
@@ -6,22 +6,22 @@
 # in separate directories.
 
 go_library(
-    name = 'lib',
-    srcs = ['kitten.go'],
-    deps = [
+    name='lib',
+    srcs=['kitten.go'],
+    deps=[
         '//proto:kitten',
         '//third_party/go:grpc',
     ],
-    visibility = ['//go/...'],
+    visibility=['//go/...'],
 )
 
 # A go_test is similar to a go_binary in that it builds a self-contained
 # executable, but it's typically run through 'plz test' to run all its
 # tests and report their results.
 go_test(
-    name = 'kitten_test',
-    srcs = ['kitten_test.go'],
-    deps = [
+    name='kitten_test',
+    srcs=['kitten_test.go'],
+    deps=[
         ':lib',
         '//third_party/go:testify',
     ],

--- a/go/server/BUILD
+++ b/go/server/BUILD
@@ -2,13 +2,13 @@
 # It is possible to put these in the same directory as the go_library rule,
 # but keeping them separate plays a little nicer with normal Go tools.
 go_binary(
-    name = 'server',
-    srcs = ['server.go'],
-    deps = [
+    name='server',
+    srcs=['server.go'],
+    deps=[
         '//go/lib',
         '//proto:kitten',
         '//third_party/go:go-flags',
         '//third_party/go:grpc',
     ],
-    visibility = ['PUBLIC'],
+    visibility=['PUBLIC'],
 )

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,12 +1,12 @@
 # A java_library compiles a number of Java files into .class
 # files and binds them up in a small .jar.
 java_library(
-    name = 'lib',
+    name='lib',
     # glob() is useful for cases like this where we want to collect
     # multiple source files of a type, often in a directory, and we
     # don't want to have to list them all explicitly.
-    srcs = glob(['src/main/java/**/*.java']),
-    deps = [
+    srcs=glob(['src/main/java/**/*.java']),
+    deps=[
         '//proto:kitten',
         '//third_party/java:args4j',
         '//third_party/java:grpc-all',
@@ -16,35 +16,35 @@ java_library(
 # A java_binary concatenates together all the libraries it depends on
 # into one uber-jar that can be deployed & run easily.
 java_binary(
-    name = 'client',
+    name='client',
     # This tells it what it should use for the Main-Class attribute in the manifest.
-    main_class = 'net.thoughtmachine.please.examples.KittenClient',
-    deps = [
+    main_class='net.thoughtmachine.please.examples.KittenClient',
+    deps=[
         ':lib',
     ],
     # Setting this marks the .jar as executable and puts a shebang on the beginning
     # so you can run it directly in a shell. It's not the default for historical
     # reasons which really aren't very interesting.
-    self_executable = True,
-    visibility = ['PUBLIC'],
+    self_executable=True,
+    visibility=['PUBLIC'],
 )
 
 java_binary(
-    name = 'server',
-    main_class = 'net.thoughtmachine.please.examples.KittenServer',
-    deps = [
+    name='server',
+    main_class='net.thoughtmachine.please.examples.KittenServer',
+    deps=[
         ':lib',
     ],
-    self_executable = True,
-    visibility = ['PUBLIC'],
+    self_executable=True,
+    visibility=['PUBLIC'],
 )
 
 # A java_test is similar to a java_binary but is run through 'plz test'
 # which runs all its tests and collects the results.
 java_test(
-    name = 'kitten_test',
-    srcs = glob(['src/test/java/**/*.java']),
-    deps = [
+    name='kitten_test',
+    srcs=glob(['src/test/java/**/*.java']),
+    deps=[
         ':lib',
         '//proto:kitten',
         '//third_party/java:junit',

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -7,7 +7,7 @@
 # See https://developers.google.com/protocol-buffers and http://grpc.io for
 # general information about gRPC and protobufs.
 grpc_library(
-    name = 'kitten',
-    srcs = ['kitten.proto'],
-    visibility = ['PUBLIC'],
+    name='kitten',
+    srcs=['kitten.proto'],
+    visibility=['PUBLIC'],
 )

--- a/python/BUILD
+++ b/python/BUILD
@@ -1,9 +1,9 @@
 # A python_library defines a reusable piece of Python code; this one we
 # will share between the client and server, and test it below.
 python_library(
-    name = 'kitten_lib',
-    srcs = ['kitten_lib.py'],
-    deps = [
+    name='kitten_lib',
+    srcs=['kitten_lib.py'],
+    deps=[
         '//proto:kitten',
         '//third_party/python:grpc',
     ],
@@ -14,33 +14,33 @@ python_library(
 # See https://github.com/pantsbuild/pex for more general information about
 # pexes and how they work and what they're useful for.
 python_binary(
-    name = 'client',
-    main = 'client.py',
-    deps = [
+    name='client',
+    main='client.py',
+    deps=[
         ':kitten_lib',
         '//proto:kitten',
         '//third_party/python:gflags',
     ],
-    visibility = ['PUBLIC'],
+    visibility=['PUBLIC'],
 )
 
 python_binary(
-    name = 'server',
-    main = 'server.py',
-    deps = [
+    name='server',
+    main='server.py',
+    deps=[
         ':kitten_lib',
         '//proto:kitten',
         '//third_party/python:gflags',
     ],
-    visibility = ['PUBLIC'],
+    visibility=['PUBLIC'],
 )
 
 # A python_test also builds a pex, but is typically executed through
 # plz test which runs all the tests in it and produces the results.
 python_test(
-    name = 'kitten_test',
-    srcs = ['kitten_test.py'],
-    deps = [
+    name='kitten_test',
+    srcs=['kitten_test.py'],
+    deps=[
         ':kitten_lib',
     ],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -25,9 +25,9 @@ for server, breed in sorted(BREEDS.items()):
         # See build_defs/integration_test.build_defs if you're curious about how
         # it's defined.
         integration_test(
-            client = client,
-            server = server,
-            port = port,
-            breed = breed,
+            client=client,
+            server=server,
+            port=port,
+            breed=breed,
         )
         port += 1

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -2,15 +2,15 @@
 # will be visible to the whole repo.
 # This is often useful for third-party packages like this where we expect
 # anyone to use them.
-package(default_visibility = ['PUBLIC'])
+package(default_visibility=['PUBLIC'])
 
 # go_get invokes, not unsurprisingly, 'go get' to fetch a third-party package.
 # Note that we can specify Git revisions or tags to pin them to a particular version.
 go_get(
-    name = 'grpc',
-    exported_deps = [':net'],
-    get = 'google.golang.org/grpc',
-    install = [
+    name='grpc',
+    exported_deps=[':net'],
+    get='google.golang.org/grpc',
+    install=[
         '',
         'balancer',
         'balancer/base',
@@ -38,103 +38,103 @@ go_get(
         'tap',
         'transport',
     ],
-    revision = 'v1.10.0',
-    deps = [
+    revision='v1.10.0',
+    deps=[
         ':protobuf',
         ':rpcstatus',
     ],
 )
 
 go_get(
-    name = 'net',
-    get = 'golang.org/x/net/...',
-    revision = '136a25c244d3019482a795d728110278d6ba09a4',
-    deps = [
+    name='net',
+    get='golang.org/x/net/...',
+    revision='136a25c244d3019482a795d728110278d6ba09a4',
+    deps=[
         ':terminal',
         ':text',
     ],
 )
 
 go_get(
-    name = 'terminal',
-    get = 'golang.org/x/crypto/ssh/terminal',
-    revision = '7b85b097bf7527677d54d3220065e966a0e3b613',
+    name='terminal',
+    get='golang.org/x/crypto/ssh/terminal',
+    revision='7b85b097bf7527677d54d3220065e966a0e3b613',
 )
 
 go_get(
-    name = 'text',
-    get = 'golang.org/x/text/...',
-    revision = '4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1',
-    deps = [
+    name='text',
+    get='golang.org/x/text/...',
+    revision='4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1',
+    deps=[
         ':tools',
     ],
 )
 
 go_get(
-    name = 'tools',
-    get = 'golang.org/x/tools',
-    install = [
+    name='tools',
+    get='golang.org/x/tools',
+    install=[
         'cover',
     ],
-    revision = '2ae76fd1560b622911f444c1e66b70a857e1de67',
+    revision='2ae76fd1560b622911f444c1e66b70a857e1de67',
 )
 
 go_get(
-    name = 'protoc-gen-go',
+    name='protoc-gen-go',
     # This produces an executable tool that we use elsewhere;
     # marking this makes it easy to use in other rules or through
     # plz run since it will only produce a single output.
     # Other rules would invoke it via a command like
     # $(exe //third_party/go:protoc-gen-go) which Please will
     # expand into the appropriate location.
-    binary = True,
-    get = [],
-    install = ['github.com/golang/protobuf/protoc-gen-go'],
-    deps = [
+    binary=True,
+    get=[],
+    install=['github.com/golang/protobuf/protoc-gen-go'],
+    deps=[
         ':protobuf',
     ],
 )
 
 go_get(
-    name = 'protobuf',
-    get = 'github.com/golang/protobuf/...',
-    revision = '130e6b02ab059e7b717a096f397c5b60111cae74',
+    name='protobuf',
+    get='github.com/golang/protobuf/...',
+    revision='130e6b02ab059e7b717a096f397c5b60111cae74',
 )
 
 go_get(
-    name = 'rpcstatus',
-    get = 'google.golang.org/genproto/googleapis/rpc/status',
-    revision = '2b5a72b8730b0b16380010cfe5286c42108d88e7',
-    deps = [':protobuf'],
+    name='rpcstatus',
+    get='google.golang.org/genproto/googleapis/rpc/status',
+    revision='2b5a72b8730b0b16380010cfe5286c42108d88e7',
+    deps=[':protobuf'],
 )
 
 go_get(
-    name = 'testify',
-    get = 'github.com/stretchr/testify',
-    install = [
+    name='testify',
+    get='github.com/stretchr/testify',
+    install=[
         'assert',
         'require',
         'vendor/github.com/davecgh/go-spew/spew',
         'vendor/github.com/pmezard/go-difflib/difflib',
     ],
-    revision = 'f390dcf405f7b83c997eac1b06768bb9f44dec18',
+    revision='f390dcf405f7b83c997eac1b06768bb9f44dec18',
     # This means that this library will only be able to be used by tests
     # (go_test rules and so forth). We'd be unlikely to use testify in
     # production code, but it can be useful to enforce these
     # things so nobody introduces such a dependency by accident.
-    test_only = True,
-    deps = [':spew'],
+    test_only=True,
+    deps=[':spew'],
 )
 
 go_get(
-    name = 'spew',
-    get = 'github.com/davecgh/go-spew/spew',
-    revision = 'ecdeabc65495df2dec95d7c4a4c3e021903035e5',
-    test_only = True,
+    name='spew',
+    get='github.com/davecgh/go-spew/spew',
+    revision='ecdeabc65495df2dec95d7c4a4c3e021903035e5',
+    test_only=True,
 )
 
 go_get(
-    name = 'go-flags',
-    get = 'github.com/jessevdk/go-flags',
-    revision = 'v1.3.0',
+    name='go-flags',
+    get='github.com/jessevdk/go-flags',
+    revision='v1.3.0',
 )

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -2,35 +2,35 @@
 # will be visible to the whole repo.
 # This is often useful for third-party packages like this where we expect
 # anyone to use them.
-package(default_visibility = ['PUBLIC'])
+package(default_visibility=['PUBLIC'])
 
 # maven_jar fetches a single .jar file from Maven.
 # Note that it doesn't fetch dependencies, we have to specify them explicitly.
 maven_jar(
-    name = 'protobuf',
-    id = 'com.google.protobuf:protobuf-java:3.4.0',
+    name='protobuf',
+    id='com.google.protobuf:protobuf-java:3.4.0',
     # Please can hash-verify downloaded artifacts so you're sure you get
     # what you're expecting. This is particularly useful when fetching things
     # from external repositories.
-    hash = 'ea1115a7983c2c23b7d90ccef4a83675f4e3df9c',
-    sources = False,  # Not available
+    hash='ea1115a7983c2c23b7d90ccef4a83675f4e3df9c',
+    sources=False,  # Not available
 )
 
 maven_jar(
-    name = 'protobuf-java-util',
-    id = 'com.google.protobuf:protobuf-java-util:3.4.0',
-    hash = '65e518040d4f932b6dbd7a255f74509cac50066e',
-    sources = False,
-    deps = [
+    name='protobuf-java-util',
+    id='com.google.protobuf:protobuf-java-util:3.4.0',
+    hash='65e518040d4f932b6dbd7a255f74509cac50066e',
+    sources=False,
+    deps=[
         ':protobuf',
     ],
 )
 
 maven_jar(
-    name = 'protoc-gen-grpc-java',
-    id = 'io.grpc:protoc-gen-grpc-java:1.6.1',
-    binary = True,
-    hash = 'c1da85124ac0f72659614a9789f42c63f8e5a8fe',
+    name='protoc-gen-grpc-java',
+    id='io.grpc:protoc-gen-grpc-java:1.6.1',
+    binary=True,
+    hash='c1da85124ac0f72659614a9789f42c63f8e5a8fe',
 )
 
 # maven_jars fetches a library and its transitive dependencies from Maven.
@@ -38,37 +38,37 @@ maven_jar(
 # sources available.
 # TODO(pebers): Revisit this once issue #120 is resolved.
 maven_jars(
-    name = 'grpc-all',
-    id = 'io.grpc:grpc-all:1.6.1',
-    exclude = [
+    name='grpc-all',
+    id='io.grpc:grpc-all:1.6.1',
+    exclude=[
         'protobuf-java',
         'protobuf-java-util',
     ],
-    deps = [
+    deps=[
         ':protobuf-java-util',
     ],
 )
 
 maven_jar(
-    name = 'junit',
-    id = 'junit:junit:4.12',
-    hash = 'sha1: a791201ac8a3d2a251045a52e264de01343ad2df',
+    name='junit',
+    id='junit:junit:4.12',
+    hash='sha1: a791201ac8a3d2a251045a52e264de01343ad2df',
     # This means that this library will only be able to be used by tests
     # (go_test rules and so forth). Obviously we'd be unlikely to use
     # junit in production code, but it can be useful to enforce these
     # things so nobody introduces such a dependency by accident.
-    test_only = True,
+    test_only=True,
 )
 
 maven_jar(
-    name = 'mockito',
-    id = 'org.mockito:mockito-all:1.10.19',
-    hash = 'e93ceaea4cf704350fbb2a450ddbb7b4e3e062e3',
-    test_only = True,
+    name='mockito',
+    id='org.mockito:mockito-all:1.10.19',
+    hash='e93ceaea4cf704350fbb2a450ddbb7b4e3e062e3',
+    test_only=True,
 )
 
 maven_jar(
-    name = 'args4j',
-    id = 'args4j:args4j:2.32',
-    hash = 'a08fb9a7217df438872f27936058f594eab29396',
+    name='args4j',
+    id='args4j:args4j:2.32',
+    hash='a08fb9a7217df438872f27936058f594eab29396',
 )

--- a/third_party/proto/BUILD
+++ b/third_party/proto/BUILD
@@ -1,5 +1,5 @@
 protoc_binary(
-    name = 'protoc',
-    version = '3.4.0',
-    visibility = ['PUBLIC'],
+    name='protoc',
+    version='3.4.0',
+    visibility=['PUBLIC'],
 )

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -2,45 +2,45 @@
 # will be visible to the whole repo.
 # This is often useful for third-party packages like this where we expect
 # anyone to use them.
-package(default_visibility = ['PUBLIC'])
+package(default_visibility=['PUBLIC'])
 
 # pip_library invokes pip to install a third-party library for us.
 # Note that dependencies have to be specified explicitly.
 pip_library(
-    name = 'protobuf',
-    version = '3.4.0',
-    outs = ['google'],
-    deps = [
+    name='protobuf',
+    version='3.4.0',
+    outs=['google'],
+    deps=[
         ':six',
     ],
 )
 
 pip_library(
-    name = 'grpc',
-    package_name = 'grpcio',
-    version = '1.9.0',
-    deps = [
+    name='grpc',
+    package_name='grpcio',
+    version='1.9.0',
+    deps=[
         ':pkg_resources',
         ':six',
     ],
 )
 
 pip_library(
-    name = 'pkg_resources',
-    package_name = 'setuptools',
-    version = '33.1.1',
+    name='pkg_resources',
+    package_name='setuptools',
+    version='33.1.1',
 )
 
 pip_library(
-    name = 'six',
-    version = '1.10.0',
+    name='six',
+    version='1.10.0',
     # If the library doesn't output into a directory the same as the
     # rule name, we have to tell Please what it's supposed to output here.
-    outs = ['six.py'],
+    outs=['six.py'],
 )
 
 pip_library(
-    name = 'gflags',
-    package_name = 'python-gflags',
-    version = '3.1.1',
+    name='gflags',
+    package_name='python-gflags',
+    version='3.1.1',
 )


### PR DESCRIPTION
E.g. From
```
pip_library(
    name = 'protobuf',
    version = '3.4.0',
    outs = ['google'],
    deps = [
        ':six',
    ],
)
```
To
```
pip_library(
    name='protobuf',
    version='3.4.0',
    outs=['google'],
    deps=[
        ':six',
    ],
)
```
to comply with the PEP8 convention also for the BUILD and *.build_defs files.